### PR TITLE
Add `?format=markdown` query parameter support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,136 @@
+name: Test Plugin
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup PHP (for composer build)
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+
+      - name: Install composer dependencies
+        run: composer install --optimize-autoloader
+
+      - name: Build prefixed vendor
+        run: composer run build
+
+      - name: Install wp-playground CLI
+        run: npm install -g @wp-playground/cli
+
+
+      - name: Start wp-playground with blueprint
+        run: |
+          echo "Starting wp-playground server in background..."
+          PLUGIN_PATH=$(realpath .)
+          echo "Plugin path: $PLUGIN_PATH"
+          npx @wp-playground/cli server --mount="$PLUGIN_PATH:/wordpress/wp-content/plugins/post-content-to-markdown" --blueprint=blueprint.json &
+          WP_PID=$!
+          echo $WP_PID > wp-playground.pid
+          echo "Started with PID: $WP_PID"
+
+          # Wait for wp-playground to be ready
+          echo "Waiting for wp-playground to start..."
+          for i in {1..30}; do
+            if curl -s http://localhost:9400 > /dev/null; then
+              echo "wp-playground is ready!"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+
+      - name: Wait for WordPress
+        run: |
+          # Wait for WordPress to be ready
+          sleep 10
+
+      - name: Test single post markdown output
+        run: |
+          echo "Testing single post with ?format=markdown"
+
+          # Check if server is responding
+          echo "Checking server status..."
+          curl -v "http://localhost:9400/" || echo "Server not responding"
+
+          echo "Testing markdown endpoint..."
+          response=$(curl -s "http://localhost:9400/hello-world/?format=markdown")
+          echo "Response received: $response"
+
+          if [[ "$response" == *"# Hello world"* ]] && [[ "$response" == *"WordPress"* ]]; then
+            echo "✅ Single post markdown query parameter test passed"
+          else
+            echo "❌ Single post markdown query parameter test failed"
+            exit 1
+          fi
+
+      - name: Test single post with Accept header
+        run: |
+          echo "Testing single post with Accept: text/markdown header"
+          response=$(curl -s -H "Accept: text/markdown" "http://localhost:9400/hello-world/")
+
+          if [[ "$response" == *"# Hello world"* ]] && [[ "$response" == *"WordPress"* ]]; then
+            echo "✅ Single post Accept header test passed"
+          else
+            echo "❌ Single post Accept header test failed"
+            exit 1
+          fi
+
+      - name: Test main feed markdown
+        run: |
+          echo "Testing main feed with ?format=markdown"
+          response=$(curl -s "http://localhost:9400/feed/?format=markdown")
+
+          if [[ "$response" == *"Markdown Feed"* ]] && [[ "$response" == *"Hello world"* ]]; then
+            echo "✅ Main feed markdown test passed"
+          else
+            echo "❌ Main feed markdown test failed"
+            exit 1
+          fi
+
+      - name: Test dedicated markdown feed
+        run: |
+          echo "Testing dedicated /feed/markdown/ endpoint"
+          response=$(curl -s "http://localhost:9400/feed/markdown/")
+
+          if [[ "$response" == *"Markdown Feed"* ]] && [[ "$response" == *"Hello world"* ]]; then
+            echo "✅ Dedicated markdown feed test passed"
+          else
+            echo "❌ Dedicated markdown feed test failed"
+            exit 1
+          fi
+
+      - name: Test content type headers
+        run: |
+          echo "Testing Content-Type headers"
+          content_type=$(curl -s -I "http://localhost:9400/hello-world/?format=markdown" | grep -i "content-type")
+
+          if [[ "$content_type" == *"text/markdown"* ]]; then
+            echo "✅ Content-Type header test passed"
+          else
+            echo "❌ Content-Type header test failed"
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: |
+          if [ -f wp-playground.pid ]; then
+            kill $(cat wp-playground.pid) || true
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Post Content to Markdown
 
-A WordPress plugin that returns post content in Markdown format when requested with an `Accept` header set to `text/markdown`.
+A WordPress plugin that returns post content in Markdown format when requested with an `Accept` header set to `text/markdown` or a `?format=markdown` query parameter.
 
 ## Requirements
 
@@ -8,21 +8,51 @@ PHP 8.1+
 
 ## Usage
 
-### Single posts
+### Accept headers (ideal for LLMs)
 
-Visit any single post on your site with the `Accept` header set to `text/markdown` to get the post content directly as Markdown.
+Send an `Accept: text/markdown` header to any of these URLs:
 
-**Example:**
+- **Single post:** `https://example.com/post-slug/` → Returns post content as Markdown
+- **Single post with comments:** `https://example.com/post-slug/feed/` → Returns post + all comments
+- **Main feed:** `https://example.com/feed/` → Returns latest posts as Markdown
+
+**Examples:**
 
 ```bash
-curl -H "Accept: text/markdown" https://example.com/my-awesome-post
+# Single post
+curl -H "Accept: text/markdown" https://example.com/my-awesome-post/
+
+# Single post with comments
+curl -H "Accept: text/markdown" https://example.com/my-awesome-post/feed/
+
+# Main feed
+curl -H "Accept: text/markdown" https://example.com/feed/
 ```
 
-### Markdown feed
+### Query parameters (accessible/shareable)
 
-Access a feed of your posts in Markdown format at `/feed/markdown/`:
+For browsers and sharing, use the `?format=markdown` query parameter:
 
-**Example:**
+- **Single post:** `https://example.com/post-slug/?format=markdown`
+- **Single post with comments:** `https://example.com/post-slug/feed/?format=markdown`
+- **Main feed:** `https://example.com/feed/?format=markdown`
+
+**Examples:**
+
+```bash
+# View in browser
+https://example.com/my-awesome-post/?format=markdown
+
+# Get post with comments
+https://example.com/my-awesome-post/feed/?format=markdown
+
+# Get main feed
+https://example.com/feed/?format=markdown
+```
+
+### Dedicated Markdown feed
+
+A dedicated Markdown feed is also available at `/feed/markdown/`:
 
 ```bash
 curl https://example.com/feed/markdown/
@@ -62,7 +92,12 @@ Welcome to WordPress. This is your first post. Edit or delete it, then start wri
 
 **Feed URL structure:**
 
-The Markdown feed is accessible at `https://yoursite.com/feed/markdown/`. Note that WordPress requires pretty permalinks to be enabled (Settings → Permalinks must be set to anything other than "Plain").
+Markdown feeds are accessible via:
+- `/feed/markdown/` - Dedicated Markdown feed
+- `/feed/?format=markdown` or `/feed/` with `Accept: text/markdown` - Main feed as Markdown
+- `/post-slug/feed/?format=markdown` or `/post-slug/feed/` with `Accept: text/markdown` - Single post with comments
+
+Note that WordPress requires pretty permalinks to be enabled (Settings → Permalinks must be set to anything other than "Plain").
 
 **Autodiscovery:**
 
@@ -212,6 +247,7 @@ add_filter('post_content_to_markdown/markdown_output', function ($markdown, $ori
 The Markdown feed is cached for 1 hour by default to optimize performance. The cache is automatically cleared when:
 - A post is published or updated
 - A post is deleted
+- Comments are added, edited, or deleted (when comments are included in feed)
 
 You can customize the cache duration using the `post_content_to_markdown/feed_cache_duration` filter.
 

--- a/blueprint.json
+++ b/blueprint.json
@@ -15,10 +15,6 @@
     {
       "step": "activatePlugin",
       "pluginPath": "post-content-to-markdown/post-content-to-markdown.php"
-    },
-    {
-      "step": "runPHP",
-      "code": "<?php flush_rewrite_rules(); ?>"
     }
   ]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/",
+  "preferredVersions": {
+    "php": "latest",
+    "wp": "latest"
+  },
+  "steps": [
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "permalink_structure": "/%postname%/"
+      }
+    },
+    {
+      "step": "activatePlugin",
+      "pluginPath": "post-content-to-markdown/post-content-to-markdown.php"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php flush_rewrite_rules(); ?>"
+    }
+  ]
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "roots/post-content-to-markdown",
     "type": "wordpress-plugin",
-    "description": "A plugin that converts post content to Markdown when requested with an `text/markdown` Accept header.",
+    "description": "A WordPress plugin that serves post content as Markdown via Accept headers or query parameters.",
     "license": "MIT",
     "homepage": "https://roots.io/sage/",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "scripts": {
-        "build": "php-scoper add-prefix --force"
+        "build": "vendor/bin/php-scoper add-prefix --force && cd vendor_prefixed && composer dump-autoload"
     },
     "require": {
         "league/html-to-markdown": "^5.1"

--- a/post-content-to-markdown.php
+++ b/post-content-to-markdown.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Post Content to Markdown
  * Description: Exposes post content as Markdown via HTTP `Accept` headers.
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: roots.io
  */
 
@@ -22,24 +22,233 @@ if (file_exists(__DIR__.'/vendor/autoload.php')) {
     require_once __DIR__.'/vendor_prefixed/vendor/autoload.php';
 }
 
+/**
+ * Check if Markdown format is requested via Accept header or query parameter
+ */
+function isMarkdownRequested()
+{
+    // Check Accept header
+    if (isset($_SERVER['HTTP_ACCEPT']) && str_contains($_SERVER['HTTP_ACCEPT'], 'text/markdown')) {
+        return true;
+    }
+
+    // Check query parameter
+    if (isset($_GET['format']) && $_GET['format'] === 'markdown') {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Serve content as Markdown based on Accept header or query parameter
+ */
 add_action('template_redirect', function () {
-    if (! isset($_SERVER['HTTP_ACCEPT']) || ! str_contains($_SERVER['HTTP_ACCEPT'], 'text/markdown')) {
+    if (! isMarkdownRequested()) {
         return;
     }
 
-    $post = get_queried_object();
-    if (! $post || ! is_a($post, 'WP_Post')) {
-        return;
-    }
-
-    $allowed_post_types = apply_filters('post_content_to_markdown/post_types', ['post']);
-
-    if (is_single() && in_array($post->post_type, $allowed_post_types, true)) {
-        header('Content-Type: text/markdown');
-        echo '# '.strip_tags($post->post_title)."\n\n".contentToMarkdown($post->post_content);
+    // Handle main feed (/feed/, /feed/markdown/, or /?feed=rss2&format=markdown)
+    if (is_feed() && ! is_singular()) {
+        outputMarkdownFeed();
         exit;
     }
+
+    // Handle single post comment feed (/post-slug/feed/ or /post-slug/?feed=rss2)
+    if (is_singular() && get_query_var('feed')) {
+        $post = get_queried_object();
+        if ($post && is_a($post, 'WP_Post')) {
+            outputSinglePostCommentFeed($post);
+            exit;
+        }
+    }
+
+    // Handle regular single post
+    if (is_singular()) {
+        $post = get_queried_object();
+        if (! $post || ! is_a($post, 'WP_Post')) {
+            return;
+        }
+
+        $allowed_post_types = apply_filters('post_content_to_markdown/post_types', ['post']);
+        if (in_array($post->post_type, $allowed_post_types, true)) {
+            header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
+            echo '# '.strip_tags($post->post_title)."\n\n".contentToMarkdown($post->post_content);
+            exit;
+        }
+    }
 });
+
+/**
+ * Output the Markdown feed
+ */
+function outputMarkdownFeed()
+{
+    // Check for cached feed
+    $cache_key = 'post_content_to_markdown_feed_'.md5(serialize([
+        apply_filters('post_content_to_markdown/feed_post_types', ['post']),
+        apply_filters('post_content_to_markdown/feed_posts_per_page', 10),
+        apply_filters('post_content_to_markdown/feed_include_comments', false),
+        apply_filters('post_content_to_markdown/feed_include_excerpt', false),
+    ]));
+
+    $cached_feed = get_transient($cache_key);
+    if ($cached_feed !== false) {
+        header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
+        echo $cached_feed;
+        exit;
+    }
+
+    ob_start();
+
+    // Feed header
+    echo '# '.get_bloginfo('name')." - Markdown Feed\n\n";
+    echo '**Description:** '.get_bloginfo('description')."\n";
+    echo '**Last Updated:** '.date('c')."\n";
+    echo '**Feed URL:** '.get_feed_link('markdown')."\n\n";
+    echo "---\n\n";
+
+    $posts = get_posts([
+        'post_type' => apply_filters('post_content_to_markdown/feed_post_types', ['post']),
+        'posts_per_page' => apply_filters('post_content_to_markdown/feed_posts_per_page', 10),
+        'post_status' => 'publish',
+        'orderby' => 'date',
+        'order' => 'DESC',
+    ]);
+
+    $include_comments = apply_filters('post_content_to_markdown/feed_include_comments', false);
+    $include_excerpt = apply_filters('post_content_to_markdown/feed_include_excerpt', false);
+
+    if (empty($posts)) {
+        echo "No posts available in this feed.\n";
+    }
+
+    foreach ($posts as $post) {
+        echo '# '.strip_tags($post->post_title)."\n\n";
+
+        // Post metadata
+        echo '**Author:** '.get_the_author_meta('display_name', $post->post_author)."\n";
+        echo '**Published:** '.get_the_date('c', $post)."\n";
+        echo '**URL:** '.get_permalink($post)."\n";
+
+        // Categories
+        $categories = get_the_category($post->ID);
+        if (! empty($categories)) {
+            $cat_names = array_map(function ($cat) {
+                return $cat->name;
+            }, $categories);
+            echo '**Categories:** '.implode(', ', $cat_names)."\n";
+        }
+
+        // Tags
+        $tags = get_the_tags($post->ID);
+        if (! empty($tags)) {
+            $tag_names = array_map(function ($tag) {
+                return $tag->name;
+            }, $tags);
+            echo '**Tags:** '.implode(', ', $tag_names)."\n";
+        }
+
+        echo "\n";
+
+        // Excerpt if enabled
+        if ($include_excerpt) {
+            $excerpt = has_excerpt($post->ID) ? $post->post_excerpt : wp_trim_words($post->post_content, 55);
+            echo '**Excerpt:** '.\PostContentToMarkdown\contentToMarkdown($excerpt)."\n\n";
+        }
+
+        // Post content
+        echo \PostContentToMarkdown\contentToMarkdown($post->post_content)."\n\n";
+
+        // Comments if enabled
+        if ($include_comments) {
+            $comments = get_comments([
+                'post_id' => $post->ID,
+                'status' => 'approve',
+                'orderby' => 'comment_date',
+                'order' => 'ASC',
+            ]);
+
+            if (! empty($comments)) {
+                echo "## Comments\n\n";
+                foreach ($comments as $comment) {
+                    echo '**'.$comment->comment_author.'** - '.get_comment_date('c', $comment)."\n\n";
+                    echo \PostContentToMarkdown\contentToMarkdown($comment->comment_content)."\n\n";
+                }
+            }
+        }
+
+        echo "---\n\n";
+    }
+
+    $feed_content = ob_get_clean();
+
+    // Cache for 1 hour
+    set_transient($cache_key, $feed_content, apply_filters('post_content_to_markdown/feed_cache_duration', HOUR_IN_SECONDS));
+
+    header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
+    echo $feed_content;
+    exit;
+}
+
+/**
+ * Output single post with comments feed
+ */
+function outputSinglePostCommentFeed($post)
+{
+    header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
+
+    echo '# '.strip_tags($post->post_title)."\n\n";
+
+    // Post metadata
+    echo '**Author:** '.get_the_author_meta('display_name', $post->post_author)."\n";
+    echo '**Published:** '.get_the_date('c', $post)."\n";
+    echo '**URL:** '.get_permalink($post)."\n";
+
+    // Categories
+    $categories = get_the_category($post->ID);
+    if (! empty($categories)) {
+        $cat_names = array_map(function ($cat) {
+            return $cat->name;
+        }, $categories);
+        echo '**Categories:** '.implode(', ', $cat_names)."\n";
+    }
+
+    // Tags
+    $tags = get_the_tags($post->ID);
+    if (! empty($tags)) {
+        $tag_names = array_map(function ($tag) {
+            return $tag->name;
+        }, $tags);
+        echo '**Tags:** '.implode(', ', $tag_names)."\n";
+    }
+
+    echo "\n";
+
+    // Post content
+    echo \PostContentToMarkdown\contentToMarkdown($post->post_content)."\n\n";
+
+    // Comments
+    $comments = get_comments([
+        'post_id' => $post->ID,
+        'status' => 'approve',
+        'orderby' => 'comment_date',
+        'order' => 'ASC',
+    ]);
+
+    if (! empty($comments)) {
+        echo "## Comments\n\n";
+        foreach ($comments as $comment) {
+            echo '**'.$comment->comment_author.'** - '.get_comment_date('c', $comment)."\n\n";
+            echo \PostContentToMarkdown\contentToMarkdown($comment->comment_content)."\n\n";
+            echo "---\n\n";
+        }
+    }
+
+    if (empty($comments)) {
+        echo "## Comments\n\nNo comments yet.\n\n";
+    }
+}
 
 /**
  * Registers a custom feed that outputs posts in Markdown format.
@@ -47,111 +256,7 @@ add_action('template_redirect', function () {
  */
 add_action('init', function () {
     add_feed('markdown', function () {
-        // Check for cached feed
-        $cache_key = 'post_content_to_markdown_feed_'.md5(serialize([
-            apply_filters('post_content_to_markdown/feed_post_types', ['post']),
-            apply_filters('post_content_to_markdown/feed_posts_per_page', 10),
-            apply_filters('post_content_to_markdown/feed_include_comments', false),
-            apply_filters('post_content_to_markdown/feed_include_excerpt', false),
-        ]));
-
-        $cached_feed = get_transient($cache_key);
-        if ($cached_feed !== false) {
-            header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
-            echo $cached_feed;
-            exit;
-        }
-
-        ob_start();
-
-        // Feed header
-        echo '# '.get_bloginfo('name')." - Markdown Feed\n\n";
-        echo '**Description:** '.get_bloginfo('description')."\n";
-        echo '**Last Updated:** '.date('c')."\n";
-        echo '**Feed URL:** '.get_feed_link('markdown')."\n\n";
-        echo "---\n\n";
-
-        $posts = get_posts([
-            'post_type' => apply_filters('post_content_to_markdown/feed_post_types', ['post']),
-            'posts_per_page' => apply_filters('post_content_to_markdown/feed_posts_per_page', 10),
-            'post_status' => 'publish',
-            'orderby' => 'date',
-            'order' => 'DESC',
-        ]);
-
-        $include_comments = apply_filters('post_content_to_markdown/feed_include_comments', false);
-        $include_excerpt = apply_filters('post_content_to_markdown/feed_include_excerpt', false);
-
-        if (empty($posts)) {
-            echo "No posts available in this feed.\n";
-        }
-
-        foreach ($posts as $post) {
-            echo '# '.strip_tags($post->post_title)."\n\n";
-
-            // Post metadata
-            echo '**Author:** '.get_the_author_meta('display_name', $post->post_author)."\n";
-            echo '**Published:** '.get_the_date('c', $post)."\n";
-            echo '**URL:** '.get_permalink($post)."\n";
-
-            // Categories
-            $categories = get_the_category($post->ID);
-            if (! empty($categories)) {
-                $cat_names = array_map(function ($cat) {
-                    return $cat->name;
-                }, $categories);
-                echo '**Categories:** '.implode(', ', $cat_names)."\n";
-            }
-
-            // Tags
-            $tags = get_the_tags($post->ID);
-            if (! empty($tags)) {
-                $tag_names = array_map(function ($tag) {
-                    return $tag->name;
-                }, $tags);
-                echo '**Tags:** '.implode(', ', $tag_names)."\n";
-            }
-
-            echo "\n";
-
-            // Excerpt if enabled
-            if ($include_excerpt) {
-                $excerpt = has_excerpt($post->ID) ? $post->post_excerpt : wp_trim_words($post->post_content, 55);
-                echo '**Excerpt:** '.\PostContentToMarkdown\contentToMarkdown($excerpt)."\n\n";
-            }
-
-            // Post content
-            echo \PostContentToMarkdown\contentToMarkdown($post->post_content)."\n\n";
-
-            // Comments if enabled
-            if ($include_comments) {
-                $comments = get_comments([
-                    'post_id' => $post->ID,
-                    'status' => 'approve',
-                    'orderby' => 'comment_date',
-                    'order' => 'ASC',
-                ]);
-
-                if (! empty($comments)) {
-                    echo "## Comments\n\n";
-                    foreach ($comments as $comment) {
-                        echo '**'.$comment->comment_author.'** - '.get_comment_date('c', $comment)."\n\n";
-                        echo \PostContentToMarkdown\contentToMarkdown($comment->comment_content)."\n\n";
-                    }
-                }
-            }
-
-            echo "---\n\n";
-        }
-
-        $feed_content = ob_get_clean();
-
-        // Cache for 1 hour
-        set_transient($cache_key, $feed_content, apply_filters('post_content_to_markdown/feed_cache_duration', HOUR_IN_SECONDS));
-
-        header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
-        echo $feed_content;
-        exit;
+        outputMarkdownFeed();
     });
 });
 

--- a/post-content-to-markdown.php
+++ b/post-content-to-markdown.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: Post Content to Markdown
- * Description: Exposes post content as Markdown via HTTP `Accept` headers.
+ * Description: Serve post content as Markdown via Accept headers or query parameters.
  * Version: 1.2.0
  * Author: roots.io
  */


### PR DESCRIPTION
## Usage examples

### Single post
```bash
# Query parameter
curl "https://example.com/hello-world/?format=markdown"

# Accept header
curl -H "Accept: text/markdown" "https://example.com/hello-world/"
```

## Single post with comments

```bash
# Query parameter
curl "https://example.com/hello-world/feed/?format=markdown"

# Accept header
curl -H "Accept: text/markdown" "https://example.com/hello-world/feed/"
```

## Main feed

```bash
# Query parameter
curl "https://example.com/feed/?format=markdown"

# Accept header
curl -H "Accept: text/markdown" "https://example.com/feed/"

# Dedicated endpoint
curl "https://example.com/feed/markdown/"
```