### PR TITLE
Add post_allowed filter to restrict Markdown output per post

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,35 @@ add_filter('post_content_to_markdown/post_types', function ($post_types) {
 
 **Default:** `['post']`
 
+#### `post_content_to_markdown/post_allowed`
+
+Filter whether a specific post is allowed to be served as Markdown. Runs after the post type check, so it only receives posts whose type is already allowed. Returning `false` short-circuits the Markdown response and falls through to the normal HTML render.
+
+```php
+add_filter('post_content_to_markdown/post_allowed', function ($allowed, $post) {
+    // Only serve Markdown for specific page slugs
+    if ($post->post_type === 'page') {
+        return in_array($post->post_name, ['example', 'example-2'], true);
+    }
+
+    return $allowed;
+}, 10, 2);
+```
+
+Or restrict by post ID:
+
+```php
+add_filter('post_content_to_markdown/post_allowed', function ($allowed, $post) {
+    if ($post->post_type === 'page') {
+        return in_array($post->ID, [1, 2, 3], true);
+    }
+
+    return $allowed;
+}, 10, 2);
+```
+
+**Default:** `true`
+
 ### Feed filters
 
 #### `post_content_to_markdown/feed_post_types`

--- a/post-content-to-markdown.php
+++ b/post-content-to-markdown.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Post Content to Markdown
  * Description: Serve post content as Markdown via Accept headers or query parameters.
- * Version: 1.3.1
+ * Version: 1.4.0
  * Author: roots.io
  * Requires PHP: 8.1
  */
@@ -85,6 +85,10 @@ add_action('template_redirect', function () {
 
         $allowed_post_types = apply_filters('post_content_to_markdown/post_types', ['post']);
         if (in_array($post->post_type, $allowed_post_types, true)) {
+            if (! apply_filters('post_content_to_markdown/post_allowed', true, $post)) {
+                return;
+            }
+
             header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
             echo '# '.strip_tags($post->post_title)."\n\n".contentToMarkdown($post->post_content);
             exit;


### PR DESCRIPTION
Allows sites to opt specific posts (or post IDs/slugs) in or out of Markdown serving without changing the `post_types` allowlist — useful when a post type is enabled but content for some posts lives in template files rather than `post_content`