### PR TITLE
Support .md URL suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ https://example.com/my-awesome-post/feed/?format=markdown
 https://example.com/feed/?format=markdown
 ```
 
+### `.md` URL suffix
+
+Appending `.md` to any permalink returns the same Markdown representation and is a first-class, shareable URL.
+
+```bash
+# Equivalent to Accept: text/markdown
+curl https://example.com/my-awesome-post.md
+```
+
+`.md` URL responses include `X-Robots-Tag: noindex, nofollow` so search engines don't index the Markdown alias alongside the canonical HTML page. Disable this feature with the `post_content_to_markdown/md_url_enabled` filter.
+
 ### Dedicated Markdown feed
 
 A dedicated Markdown feed is also available at `/feed/markdown/`:
@@ -177,6 +188,16 @@ add_filter('post_content_to_markdown/post_allowed', function ($allowed, $post) {
 
     return $allowed;
 }, 10, 2);
+```
+
+**Default:** `true`
+
+#### `post_content_to_markdown/md_url_enabled`
+
+Controls whether `.md` URL suffixes (e.g. `/about.md`) are treated as a Markdown request. Enabled by default so consumers get shareable Markdown URLs automatically. Disable if you'd rather only accept Markdown requests via the `Accept` header or `?format=markdown` query parameter.
+
+```php
+add_filter('post_content_to_markdown/md_url_enabled', '__return_false');
 ```
 
 **Default:** `true`

--- a/post-content-to-markdown.php
+++ b/post-content-to-markdown.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Post Content to Markdown
  * Description: Serve post content as Markdown via Accept headers or query parameters.
- * Version: 1.5.0
+ * Version: 1.6.0
  * Author: roots.io
  * Requires PHP: 8.1
  */
@@ -71,11 +71,26 @@ function acceptQuality($accept, $type, $subtype)
 }
 
 /**
+ * Whether the current request reached the site via a `.md` URL suffix
+ * (e.g. /about.md). Internally rewritten to the underlying URL during
+ * plugins_loaded; this flag preserves the Markdown-preferred signal for
+ * later hooks.
+ */
+function isMdUrlRequest()
+{
+    return ! empty($GLOBALS['post_content_to_markdown_md_url']);
+}
+
+/**
  * Check if Markdown is preferred over HTML via Accept header q-values,
- * or requested explicitly via ?format=markdown.
+ * a .md URL suffix, or the ?format=markdown query parameter.
  */
 function isMarkdownRequested()
 {
+    if (isMdUrlRequest()) {
+        return true;
+    }
+
     if (isset($_GET['format']) && $_GET['format'] === 'markdown') {
         return true;
     }
@@ -93,11 +108,16 @@ function isMarkdownRequested()
 
 /**
  * Whether the client's Accept header allows any representation we can serve
- * (text/html or text/markdown). Missing Accept counts as acceptable per
- * RFC 9110 (absence means any type is acceptable).
+ * (text/html or text/markdown). A .md URL suffix is always acceptable since
+ * the URL itself is the preference signal. Missing Accept counts as
+ * acceptable per RFC 9110 (absence means any type is acceptable).
  */
 function isAcceptable()
 {
+    if (isMdUrlRequest()) {
+        return true;
+    }
+
     $accept = $_SERVER['HTTP_ACCEPT'] ?? '';
     if ($accept === '') {
         return true;
@@ -108,6 +128,51 @@ function isAcceptable()
 }
 
 /**
+ * Detect a .md URL suffix (e.g. /about.md) and internally rewrite REQUEST_URI
+ * to the underlying URL so existing WP and custom routing matches as usual.
+ * The URL the client hit is preserved in the address bar; this rewrite only
+ * affects server-side lookup. A flag is set so isMarkdownRequested() and
+ * isAcceptable() know the request explicitly asked for Markdown.
+ */
+add_action('plugins_loaded', function () {
+    if (! apply_filters('post_content_to_markdown/md_url_enabled', true)) {
+        return;
+    }
+
+    $uri = $_SERVER['REQUEST_URI'] ?? '';
+    $parts = explode('?', $uri, 2);
+    $path = $parts[0];
+    $query = isset($parts[1]) ? '?'.$parts[1] : '';
+
+    if (! preg_match('#\.md$#', $path)) {
+        return;
+    }
+
+    // rest_url() depends on $wp_rewrite which isn't ready at plugins_loaded
+    // priority 0, so build the REST path from home_url() + rest_get_url_prefix().
+    $home_path = rtrim((string) wp_parse_url(home_url('/'), PHP_URL_PATH), '/').'/';
+    $skip_prefixes = array_filter([
+        wp_parse_url(admin_url(), PHP_URL_PATH),
+        $home_path.rest_get_url_prefix().'/',
+        wp_parse_url(wp_login_url(), PHP_URL_PATH),
+        wp_parse_url(home_url('xmlrpc.php'), PHP_URL_PATH),
+    ]);
+    foreach ($skip_prefixes as $skip) {
+        if (str_starts_with($path, $skip)) {
+            return;
+        }
+    }
+
+    $stripped = substr($path, 0, -3);
+    if ($stripped === '' || ! str_ends_with($stripped, '/')) {
+        $stripped .= '/';
+    }
+
+    $_SERVER['REQUEST_URI'] = $stripped.$query;
+    $GLOBALS['post_content_to_markdown_md_url'] = true;
+}, 0);
+
+/**
  * Tell caching plugins (WP Super Cache, etc.) to skip caching for markdown requests.
  * This runs early to ensure the constant is set before caching plugins check it.
  */
@@ -115,6 +180,22 @@ add_action('plugins_loaded', function () {
     if (isMarkdownRequested() && ! defined('DONOTCACHEPAGE')) {
         define('DONOTCACHEPAGE', true);
     }
+});
+
+/**
+ * Add X-Robots-Tag: noindex, nofollow to .md URL responses so search engines
+ * don't index the Markdown alias alongside the canonical HTML page.
+ */
+add_action('send_headers', function () {
+    if (is_admin()) {
+        return;
+    }
+
+    if (! isMdUrlRequest()) {
+        return;
+    }
+
+    header('X-Robots-Tag: noindex, nofollow', false);
 });
 
 /**

--- a/tests/Feature/MarkdownOutputTest.php
+++ b/tests/Feature/MarkdownOutputTest.php
@@ -122,6 +122,12 @@ test('.md URL response carries X-Robots-Tag: noindex, nofollow', function () {
         ->and($response['headers']['x-robots-tag'])->toContain('noindex');
 });
 
+test('regular URL response does not carry noindex from this plugin', function () {
+    $response = makeRequest('/hello-world/');
+
+    expect($response['headers']['x-robots-tag'] ?? '')->not->toContain('noindex');
+});
+
 test('.md URL overrides Accept header so the shared URL wins', function () {
     $response = makeRequest('/hello-world.md', [
         'Accept' => 'text/html',

--- a/tests/Feature/MarkdownOutputTest.php
+++ b/tests/Feature/MarkdownOutputTest.php
@@ -106,3 +106,51 @@ test('markdown response advertises Vary: Accept', function () {
     expect($response['headers'])->toHaveKey('vary')
         ->and($response['headers']['vary'])->toContain('Accept');
 });
+
+test('.md URL suffix serves markdown', function () {
+    $response = makeRequest('/hello-world.md');
+
+    expect($response['status'])->toBe(200)
+        ->and($response['headers']['content-type'])->toContain('text/markdown')
+        ->and($response['body'])->toContain('# Hello world');
+});
+
+test('.md URL response carries X-Robots-Tag: noindex, nofollow', function () {
+    $response = makeRequest('/hello-world.md');
+
+    expect($response['headers'])->toHaveKey('x-robots-tag')
+        ->and($response['headers']['x-robots-tag'])->toContain('noindex');
+});
+
+test('.md URL overrides Accept header so the shared URL wins', function () {
+    $response = makeRequest('/hello-world.md', [
+        'Accept' => 'text/html',
+    ]);
+
+    expect($response['status'])->toBe(200)
+        ->and($response['headers']['content-type'])->toContain('text/markdown');
+});
+
+test('.md suffix on REST paths is ignored (skipped)', function () {
+    $response = makeRequest('/wp-json/wp/v2/posts.md');
+
+    expect($response['headers']['content-type'] ?? '')->not->toContain('text/markdown');
+});
+
+test('.md suffix on wp-admin paths is ignored (skipped)', function () {
+    $response = makeRequest('/wp-admin/index.php.md');
+
+    expect($response['headers']['content-type'] ?? '')->not->toContain('text/markdown');
+});
+
+test('.md suffix on wp-login.php is ignored (skipped)', function () {
+    $response = makeRequest('/wp-login.php.md');
+
+    expect($response['headers']['content-type'] ?? '')->not->toContain('text/markdown');
+});
+
+test('.md URL for a non-existent page returns 404', function () {
+    $response = makeRequest('/does-not-exist.md');
+
+    expect($response['status'])->toBe(404);
+});


### PR DESCRIPTION
Appending `.md` to any permalink (e.g. `/about.md`) now returns the Markdown representation without requiring an `Accept` header or query parameter.

Responses carry `X-Robots-Tag: noindex, nofollow` so search engines don't index the Markdown alias alongside the canonical HTML page

Opt-out via the `post_content_to_markdown/md_url_enabled` filter