### PR TITLE
Performance, discovery, and observability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ curl https://example.com/my-awesome-post.md
 
 `.md` URL responses include `X-Robots-Tag: noindex, nofollow` so search engines don't index the Markdown alias alongside the canonical HTML page. Disable this feature with the `post_content_to_markdown/md_url_enabled` filter.
 
+HTML responses advertise the Markdown representation two ways so both RFC 8288-aware crawlers and HTML-parsing clients can discover it without sending `Accept: text/markdown`:
+
+```
+Link: <https://example.com/my-awesome-post.md>; rel="alternate"; type="text/markdown"
+```
+
+```html
+<link rel="alternate" type="text/markdown" href="https://example.com/my-awesome-post.md">
+```
+
+### Response headers
+
+Markdown responses carry:
+
+- `Content-Type: text/markdown; charset=utf-8`
+- `Vary: Accept` — tells caches to key by `Accept` so the HTML and Markdown representations don't cross-serve.
+- `X-Markdown-Source: accept | md-url | query` — identifies how the client asked for Markdown. Useful for inspecting agent traffic in access logs.
+
 ### Dedicated Markdown feed
 
 A dedicated Markdown feed is also available at `/feed/markdown/`:
@@ -222,6 +240,16 @@ add_filter('post_content_to_markdown/emit_vary', '__return_false');
 
 **Default:** `true`
 
+#### `post_content_to_markdown/cache_md_urls`
+
+By default the plugin sets `DONOTCACHEPAGE` for every Markdown request so WordPress page caches (WP Super Cache, Batcache, etc.) don't cross-serve a Markdown body to an HTML client. `.md` URLs are a distinct URL key and safe to cache in principle, but WP page caches can transform response bodies assuming HTML (gzip, footer injection, cache-comment insertion), so caching them is opt-in. Enable if your page cache passes non-HTML bodies through untouched.
+
+```php
+add_filter('post_content_to_markdown/cache_md_urls', '__return_true');
+```
+
+**Default:** `false`
+
 ### Feed filters
 
 #### `post_content_to_markdown/feed_post_types`
@@ -324,12 +352,18 @@ add_filter('post_content_to_markdown/markdown_output', function ($markdown, $ori
 
 ## Performance
 
-The Markdown feed is cached for 1 hour by default to optimize performance. The cache is automatically cleared when:
+The HTML → Markdown conversion is cached at the object-cache layer (`wp_cache_get` / `wp_cache_set`) keyed on a content hash. Sites with a persistent object cache like Redis or Memcached avoid re-running block rendering, shortcode expansion, and the `league/html-to-markdown` conversion on repeat hits. Cache entries expire after an hour; content changes produce a new hash and a fresh entry, so no explicit invalidation is needed.
+
+The Markdown feed is cached for 1 hour by default via a transient. The cache is automatically cleared when:
 - A post is published or updated
 - A post is deleted
 - Comments are added, edited, or deleted (when comments are included in feed)
 
 You can customize the cache duration using the `post_content_to_markdown/feed_cache_duration` filter.
+
+## CDN configuration
+
+Most WordPress sites don't cache HTML at the CDN (WordPress is dynamic by default), in which case `Vary: Accept` has no practical cost. If you do cache HTML at the edge, `Vary: Accept` will fragment cache entries per user-agent `Accept` string (Chrome, Safari, agent UAs all send different values). Normalize `Accept` at the edge to two buckets — "wants Markdown" and "anything else" — before it reaches origin, then cache each bucket separately. On Cloudflare, a Cache Rule with a custom cache key that includes a normalized `Accept` header handles this; Cloudflare's [Markdown for Agents](https://blog.cloudflare.com/markdown-for-agents/) feature automates the normalization on supported zones.
 
 ## Resources
 

--- a/post-content-to-markdown.php
+++ b/post-content-to-markdown.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Post Content to Markdown
  * Description: Serve post content as Markdown via Accept headers, .md URL suffix, or query parameters.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: roots.io
  * Requires PHP: 8.1
  */
@@ -107,6 +107,34 @@ function isMarkdownRequested()
 }
 
 /**
+ * Identify how the client asked for Markdown: md-url (URL suffix), query
+ * (?format=markdown), or accept (Accept header). Emitted as X-Markdown-Source
+ * so ops can see the negotiation mix in access logs.
+ */
+function markdownSource()
+{
+    if (isMdUrlRequest()) {
+        return 'md-url';
+    }
+
+    if (isset($_GET['format']) && $_GET['format'] === 'markdown') {
+        return 'query';
+    }
+
+    return 'accept';
+}
+
+/**
+ * Send the response headers common to every Markdown output path.
+ */
+function sendMarkdownHeaders()
+{
+    header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
+    header('Vary: Accept', false);
+    header('X-Markdown-Source: '.markdownSource(), false);
+}
+
+/**
  * Whether the client's Accept header allows any representation we can serve
  * (text/html or text/markdown). A .md URL suffix is always acceptable since
  * the URL itself is the preference signal. Missing Accept counts as
@@ -173,13 +201,22 @@ add_action('plugins_loaded', function () {
 }, 0);
 
 /**
- * Tell caching plugins (WP Super Cache, etc.) to skip caching for markdown requests.
- * This runs early to ensure the constant is set before caching plugins check it.
+ * Tell caching plugins (WP Super Cache, etc.) to skip caching for same-URL
+ * Accept-header negotiation, where the cache key wouldn't distinguish the
+ * Markdown and HTML representations. .md URL requests are a distinct URL
+ * and safely cacheable, but WP page caches may transform the body assuming
+ * HTML (gzip, footer injection), so the opt-in stays off by default.
  */
 add_action('plugins_loaded', function () {
-    if (isMarkdownRequested() && ! defined('DONOTCACHEPAGE')) {
-        define('DONOTCACHEPAGE', true);
+    if (! isMarkdownRequested() || defined('DONOTCACHEPAGE')) {
+        return;
     }
+
+    if (isMdUrlRequest() && apply_filters('post_content_to_markdown/cache_md_urls', false)) {
+        return;
+    }
+
+    define('DONOTCACHEPAGE', true);
 });
 
 /**
@@ -213,6 +250,64 @@ add_action('send_headers', function () {
     }
 
     header('Vary: Accept', false);
+});
+
+/**
+ * Return the .md URL for the current singular post if the plugin would serve
+ * a Markdown representation, or null when no alternate exists or should be
+ * advertised (admin, Markdown response, disallowed post, filter disabled).
+ */
+function currentMdAlternateUrl()
+{
+    if (is_admin() || isMarkdownRequested() || ! is_singular()) {
+        return null;
+    }
+
+    if (! apply_filters('post_content_to_markdown/md_url_enabled', true)) {
+        return null;
+    }
+
+    $post = get_queried_object();
+    if (! $post || ! is_a($post, 'WP_Post')) {
+        return null;
+    }
+
+    $allowed = apply_filters('post_content_to_markdown/post_types', ['post']);
+    if (! in_array($post->post_type, $allowed, true)) {
+        return null;
+    }
+
+    if (! apply_filters('post_content_to_markdown/post_allowed', true, $post)) {
+        return null;
+    }
+
+    return rtrim(get_permalink($post), '/').'.md';
+}
+
+/**
+ * Advertise the .md sibling on HTML responses so RFC 8288-aware crawlers can
+ * discover the Markdown representation without sending Accept: text/markdown.
+ */
+add_action('template_redirect', function () {
+    $md_url = currentMdAlternateUrl();
+    if ($md_url === null) {
+        return;
+    }
+
+    header('Link: <'.esc_url_raw($md_url).'>; rel="alternate"; type="text/markdown"', false);
+});
+
+/**
+ * Also advertise the .md sibling inside <head> so HTML-parsing clients
+ * (browsers, feed readers) discover it alongside the HTTP Link header.
+ */
+add_action('wp_head', function () {
+    $md_url = currentMdAlternateUrl();
+    if ($md_url === null) {
+        return;
+    }
+
+    echo '<link rel="alternate" type="text/markdown" href="'.esc_url($md_url).'">'."\n";
 });
 
 /**
@@ -276,8 +371,7 @@ add_action('template_redirect', function () {
                 return;
             }
 
-            header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
-            header('Vary: Accept', false);
+            sendMarkdownHeaders();
             echo '# '.strip_tags($post->post_title)."\n\n".contentToMarkdown($post->post_content);
             exit;
         }
@@ -299,8 +393,7 @@ function outputMarkdownFeed()
 
     $cached_feed = get_transient($cache_key);
     if ($cached_feed !== false) {
-        header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
-        header('Vary: Accept', false);
+        sendMarkdownHeaders();
         echo $cached_feed;
         exit;
     }
@@ -392,8 +485,7 @@ function outputMarkdownFeed()
     // Cache for 1 hour
     set_transient($cache_key, $feed_content, apply_filters('post_content_to_markdown/feed_cache_duration', HOUR_IN_SECONDS));
 
-    header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
-    header('Vary: Accept', false);
+    sendMarkdownHeaders();
     echo $feed_content;
     exit;
 }
@@ -403,8 +495,7 @@ function outputMarkdownFeed()
  */
 function outputSinglePostCommentFeed($post)
 {
-    header('Content-Type: text/markdown; charset='.get_option('blog_charset'));
-    header('Vary: Accept', false);
+    sendMarkdownHeaders();
 
     echo '# '.strip_tags($post->post_title)."\n\n";
 
@@ -559,6 +650,12 @@ function contentToMarkdown($content)
         return '';
     }
 
+    $cache_key = 'md_'.md5($content);
+    $cached = wp_cache_get($cache_key, 'post_content_to_markdown');
+    if ($cached !== false) {
+        return $cached;
+    }
+
     // Render dynamic Gutenberg blocks and shortcodes so the HTML is complete before conversion.
     $content = do_blocks($content);
     $content = do_shortcode($content);
@@ -598,5 +695,9 @@ function contentToMarkdown($content)
     // Clean up excessive newlines (more than 2 consecutive)
     $markdown = preg_replace("/\n{3,}/", "\n\n", $markdown);
 
-    return apply_filters('post_content_to_markdown/markdown_output', $markdown, $content);
+    $markdown = apply_filters('post_content_to_markdown/markdown_output', $markdown, $content);
+
+    wp_cache_set($cache_key, $markdown, 'post_content_to_markdown', HOUR_IN_SECONDS);
+
+    return $markdown;
 }

--- a/tests/Feature/MarkdownOutputTest.php
+++ b/tests/Feature/MarkdownOutputTest.php
@@ -160,3 +160,39 @@ test('.md URL for a non-existent page returns 404', function () {
 
     expect($response['status'])->toBe(404);
 });
+
+test('HTML response advertises the .md alternate via a Link header', function () {
+    $response = makeRequest('/hello-world/');
+
+    expect($response['headers'])->toHaveKey('link')
+        ->and($response['headers']['link'])->toContain('rel="alternate"')
+        ->and($response['headers']['link'])->toContain('type="text/markdown"');
+});
+
+test('HTML head includes a <link rel="alternate" type="text/markdown">', function () {
+    $response = makeRequest('/hello-world/');
+
+    expect($response['body'])->toContain('rel="alternate"')
+        ->and($response['body'])->toContain('type="text/markdown"')
+        ->and($response['body'])->toContain('href="');
+});
+
+test('markdown via Accept reports X-Markdown-Source: accept', function () {
+    $response = makeRequest('/hello-world/', [
+        'Accept' => 'text/markdown',
+    ]);
+
+    expect($response['headers']['x-markdown-source'] ?? '')->toBe('accept');
+});
+
+test('markdown via .md URL reports X-Markdown-Source: md-url', function () {
+    $response = makeRequest('/hello-world.md');
+
+    expect($response['headers']['x-markdown-source'] ?? '')->toBe('md-url');
+});
+
+test('markdown via query parameter reports X-Markdown-Source: query', function () {
+    $response = makeRequest('/hello-world/?format=markdown');
+
+    expect($response['headers']['x-markdown-source'] ?? '')->toBe('query');
+});


### PR DESCRIPTION
## Summary

- **Object cache conversion output.** `contentToMarkdown()` now wraps the block-rendering + shortcode + HTML→Markdown pipeline with `wp_cache_get` / `wp_cache_set` keyed on a content hash. Sites with Redis/Memcached avoid re-running the conversion on repeat hits; no invalidation concern since a content change produces a new hash.
- **Advertise the `.md` alternate on HTML responses.** Emit `Link: <…>; rel="alternate"; type="text/markdown"` as an HTTP header and `<link rel="alternate" type="text/markdown" href="…">` inside `<head>`. RFC 8288-aware crawlers and HTML-parsing clients can now discover the Markdown representation without sending `Accept: text/markdown`.
- **`X-Markdown-Source` response header.** Every Markdown response now carries `X-Markdown-Source: accept | md-url | query` so operators can see the negotiation mix in access logs without reading bodies.
- **`post_content_to_markdown/cache_md_urls` filter.** `.md` URLs are distinct cache keys and in principle safely cacheable by WP page caches, but Super Cache / Batcache / etc. can transform response bodies assuming HTML (gzip, footer injection). Default stays `false`; sites whose page cache passes non-HTML bodies through untouched can opt in.
- **Tests.** Added coverage for the `<link>` in `<head>`, the `Link:` HTTP header, and the three `X-Markdown-Source` values.

Bumps to 1.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)