### PR TITLE
Move markdown_output filter out of the cached path

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,18 @@ add_filter('post_content_to_markdown/feed_cache_duration', function ($duration) 
 
 ### Conversion filters
 
+#### `post_content_to_markdown/conversion_cache_duration`
+
+Filter the cache duration for the HTML → Markdown conversion result in seconds. The conversion is memoized per content hash in the object cache; shorten this TTL if your content renders dynamically (e.g. dynamic blocks, request-aware shortcodes) and you want fresher output.
+
+```php
+add_filter('post_content_to_markdown/conversion_cache_duration', function ($duration) {
+    return 5 * MINUTE_IN_SECONDS;
+});
+```
+
+**Default:** `HOUR_IN_SECONDS` (1 hour)
+
 #### `post_content_to_markdown/converter_options`
 
 Filter the HTML to Markdown converter options.
@@ -352,7 +364,9 @@ add_filter('post_content_to_markdown/markdown_output', function ($markdown, $ori
 
 ## Performance
 
-The HTML → Markdown conversion is cached at the object-cache layer (`wp_cache_get` / `wp_cache_set`) keyed on a content hash. Sites with a persistent object cache like Redis or Memcached avoid re-running block rendering, shortcode expansion, and the `league/html-to-markdown` conversion on repeat hits. Cache entries expire after an hour; content changes produce a new hash and a fresh entry, so no explicit invalidation is needed.
+The HTML → Markdown conversion is cached at the object-cache layer (`wp_cache_get` / `wp_cache_set`) keyed on a content hash. Sites with a persistent object cache like Redis or Memcached avoid re-running block rendering, shortcode expansion, and the `league/html-to-markdown` conversion on repeat hits. Cache entries expire after an hour (filterable via `post_content_to_markdown/conversion_cache_duration`); content changes produce a new hash and a fresh entry, so no explicit invalidation is needed.
+
+The cache assumes that rendering the same post content produces the same output. If you use dynamic blocks or shortcodes whose output varies by request context (e.g. current user, current time, site option that changes mid-TTL), the first render is frozen for the TTL window. Shorten the TTL via the filter above for content where that matters. The `post_content_to_markdown/markdown_output` filter runs on every request (after the cache lookup), so per-request customization there works without fighting the cache.
 
 The Markdown feed is cached for 1 hour by default via a transient. The cache is automatically cleared when:
 - A post is published or updated

--- a/post-content-to-markdown.php
+++ b/post-content-to-markdown.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: Post Content to Markdown
  * Description: Serve post content as Markdown via Accept headers, .md URL suffix, or query parameters.
- * Version: 1.7.0
+ * Version: 1.7.1
  * Author: roots.io
  * Requires PHP: 8.1
  */
@@ -653,19 +653,19 @@ function contentToMarkdown($content)
     $cache_key = 'md_'.md5($content);
     $cached = wp_cache_get($cache_key, 'post_content_to_markdown');
     if ($cached !== false) {
-        return $cached;
+        return apply_filters('post_content_to_markdown/markdown_output', $cached, $content);
     }
 
     // Render dynamic Gutenberg blocks and shortcodes so the HTML is complete before conversion.
-    $content = do_blocks($content);
-    $content = do_shortcode($content);
+    $rendered = do_blocks($content);
+    $rendered = do_shortcode($rendered);
 
     // Flatten <pre> blocks so syntax-highlighter markup doesn't leak into the code fence.
-    $content = preg_replace_callback('#<pre\b[^>]*>(.*?)</pre>#is', function ($m) {
+    $rendered = preg_replace_callback('#<pre\b[^>]*>(.*?)</pre>#is', function ($m) {
         $inner = html_entity_decode(strip_tags($m[1]), ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
         return '<pre><code>'.htmlspecialchars($inner, ENT_QUOTES | ENT_HTML5, 'UTF-8').'</code></pre>';
-    }, $content);
+    }, $rendered);
 
     $default_options = [
         'header_style' => 'atx',
@@ -690,14 +690,17 @@ function contentToMarkdown($content)
         $converter->getEnvironment()->addConverter(new $table_converter_class);
     }
 
-    $markdown = $converter->convert($content);
+    $markdown = $converter->convert($rendered);
 
     // Clean up excessive newlines (more than 2 consecutive)
     $markdown = preg_replace("/\n{3,}/", "\n\n", $markdown);
 
-    $markdown = apply_filters('post_content_to_markdown/markdown_output', $markdown, $content);
+    wp_cache_set(
+        $cache_key,
+        $markdown,
+        'post_content_to_markdown',
+        apply_filters('post_content_to_markdown/conversion_cache_duration', HOUR_IN_SECONDS)
+    );
 
-    wp_cache_set($cache_key, $markdown, 'post_content_to_markdown', HOUR_IN_SECONDS);
-
-    return $markdown;
+    return apply_filters('post_content_to_markdown/markdown_output', $markdown, $content);
 }


### PR DESCRIPTION
## Summary

- **`markdown_output` filter now runs per-request.** Previously the filter was applied once and its result cached, so any request-dependent logic in user-installed filters (current user, current time, request context) was frozen into the first cached value. The filter now runs after the cache lookup on both hit and miss paths — expensive `do_blocks` / `do_shortcode` / `league/html-to-markdown` work stays memoized; customizations stay live.
- **Filter signature consistency fix.** The function overwrote `$content` with `do_blocks` / `do_shortcode` / pre-flattened HTML before passing it to the filter as `$original_html`, contradicting the README's documented "original HTML content" description. Separate `$rendered` from `$content` so both hit and miss paths pass the raw function argument. Users writing filters can rely on `$original_html` meaning what the docs say it means.
- **`post_content_to_markdown/conversion_cache_duration` filter.** Tunable TTL for the conversion cache, matching the existing `feed_cache_duration` pattern. Default stays at `HOUR_IN_SECONDS`.
- **README.** Performance section notes that the conversion cache assumes deterministic rendering and points at the new TTL filter for dynamic-content cases. New filter documented under "Conversion filters".

Bumps to 1.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)